### PR TITLE
Change "P prop" to "P true" in evidence update

### DIFF
--- a/logicaltheory.tex
+++ b/logicaltheory.tex
@@ -340,13 +340,13 @@ into account the computational behavior of expressions:
 In practice, when it is clear that $P$ is canonical, then we will simply say,
 ``To know $\isprop{P}$ is to know what counts as a canonical verification of
 $P$''. As an example, then, we will update the evidence of the following assertion:
-\[\hyp{\isprop{P\supset Q}}{\isprop{P},\hyp{\isprop{Q}}{\isprop{P}}}
+\[\hyp{\isprop{P\supset Q}}{\isprop{P},\hyp{\isprop{Q}}{\istrue{P}}}
 \]
 The meaning
 of this, expanded into spoken language, is as follows:
 \begin{quote}
   To know $\hyp{\isprop{P\supset
-Q}}{\isprop{P},\hyp{\isprop{Q}}{\isprop{P}}}$ is to know what counts
+Q}}{\isprop{P},\hyp{\isprop{Q}}{\istrue{P}}}$ is to know what counts
   as a canonical (direct) verification of $P\supset Q$ under the
   circumstances that $\reduce{P}{P'}$, such that one knows what counts
   as a canonical verification $P'$, and, if one has such a verification,


### PR DESCRIPTION
Hi Jon,

I'm very new to this, but it seems that this could be a typo, and the judgement should reflect the same one from page 8 (`P ⊃ Q prop (P prop, Q prop (P true))`)?

Thanks for publishing this paper,
Brian